### PR TITLE
Add required camera parameters

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,6 +14,8 @@
 
 include device/sony/yukon/PlatformConfig.mk
 
+TARGET_SPECIFIC_HEADER_PATH += device/sony/eagle/include
+
 TARGET_RECOVERY_FSTAB = device/sony/eagle/rootdir/fstab.eagle
 
 TARGET_BOOTLOADER_BOARD_NAME := D2303

--- a/include/camera/CameraParametersExtra.h
+++ b/include/camera/CameraParametersExtra.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define CAMERA_PARAMETERS_EXTRA_C \
+const char CameraParameters::FOCUS_MODE_MANUAL_POSITION[] = "manual"; \
+const char CameraParameters::WHITE_BALANCE_MANUAL_CCT[] = "manual-cct";
+
+#define CAMERA_PARAMETERS_EXTRA_H \
+    static const char FOCUS_MODE_MANUAL_POSITION[]; \
+    static const char WHITE_BALANCE_MANUAL_CCT[];


### PR DESCRIPTION
This was dropped in CM14 http://review.cyanogenmod.org/#/c/162428/