### PR TITLE
[DO NOT MERGE] add user/group to wifimactool script

### DIFF
--- a/rootdir/init.eagle.rc
+++ b/rootdir/init.eagle.rc
@@ -112,6 +112,8 @@ service memsicd /system/bin/memsicd
 # WiFi MAC
 service wifimactool /system/bin/sh /system/etc/wifimactool.sh
     class main    
+    user system
+    group system bluetooth
     oneshot
 
 # WCNSS service


### PR DESCRIPTION
This is wrong - this script is not for bluetooth, but let's see if it makes SELinux happy.