### PR TITLE
sensors: Use multiHAL to load both sensor libs (1/2)

### DIFF
--- a/rootdir/system/etc/_hals.conf
+++ b/rootdir/system/etc/_hals.conf
@@ -1,1 +1,2 @@
 sensors.eagle.so
+sensorsecond.eagle.so


### PR DESCRIPTION
Now when we have multiHAL, we can ditch our own sensor wrapper